### PR TITLE
Fix a crash when leaving search

### DIFF
--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/activity/TopicActivity.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/activity/TopicActivity.java
@@ -108,12 +108,6 @@ public class TopicActivity extends SearchActivity {
     }
 
     @Override
-    public void hideSearch() {
-        super.hideSearch();
-        actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
-    }
-
-    @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.uv_portal, menu);
         setupScopedSearch(menu);


### PR DESCRIPTION
The base class implementation restores the ActionBar navigation mode already 
and does it correctly.

Fixes: https://github.com/uservoice/uservoice-android-sdk/issues/213 Fixes:
https://eisdev-jira.aquent.com/browse/RFM-2370 - Fix IllegalStateException in
android.view.ViewGroup.addViewInner, line 3936
